### PR TITLE
Disallow transfers to and from the zero address in ERC20 functions.

### DIFF
--- a/contracts/ERC20FeeToken.sol
+++ b/contracts/ERC20FeeToken.sol
@@ -138,6 +138,8 @@ contract ERC20FeeToken is Owned, SafeDecimalMath {
         public
         returns (bool)
     {
+        require(_to != address(0));
+
         // The fee is deducted from the sender's balance, in addition to
         // the transferred quantity.
         uint fee = transferFeeIncurred(_value);
@@ -164,6 +166,8 @@ contract ERC20FeeToken is Owned, SafeDecimalMath {
         public
         returns (bool)
     {
+        require(_from != address(0));
+        require(_to != address(0));
         // The fee is deducted from the sender's balance, in addition to
         // the transferred quantity.
         uint fee = transferFeeIncurred(_value);
@@ -202,6 +206,13 @@ contract ERC20FeeToken is Owned, SafeDecimalMath {
         returns (bool)
     {
         require(msg.sender == feeAuthority);
+        require(account != address(0));
+        
+        // 0-value withdrawals do nothing.
+        if (value == 0) {
+            return false;
+        }
+
         // Safe subtraction ensures an exception is thrown if the balance is insufficient.
         feePool = safeSub(feePool, value);
         balanceOf[account] = safeAdd(balanceOf[account], value);

--- a/contracts/ERC20Token.sol
+++ b/contracts/ERC20Token.sol
@@ -58,6 +58,8 @@ contract ERC20Token is SafeDecimalMath {
         public
         returns (bool)
     {
+        require(_to != address(0));
+
         // Zero-value transfers must fire the transfer event...
         Transfer(msg.sender, _to, _value);
 
@@ -77,6 +79,9 @@ contract ERC20Token is SafeDecimalMath {
         public
         returns (bool)
     {
+        require(_from != address(0));
+        require(_to != address(0));
+
         // Zero-value transfers must fire the transfer event...
         Transfer(_from, _to, _value);
 


### PR DESCRIPTION
* ERC20Token.transfer, ERC20FeeToken.transfer require a nonzero recipient.
* ERC20Token.transferFrom, ERC20FeeToken.transferFrom require nonzero sender and recipient.
* ERC20FeeToken.withdrawFee does nothing if zero fees are withdrawn.