### PR TITLE
small changes to havven to add basic functions and cleanup

### DIFF
--- a/contracts/ExternStateToken.sol
+++ b/contracts/ExternStateToken.sol
@@ -57,8 +57,9 @@ contract ExternStateToken is SafeDecimalMath, SelfDestructible, Proxyable {
      * @param _tokenState The TokenState contract address.
      * @param _owner The owner of this contract.
      */
-    constructor(address _proxy, string _name, string _symbol, uint _totalSupply,
-                TokenState _tokenState, address _owner)
+    constructor(address _proxy, TokenState _tokenState,
+                string _name, string _symbol, uint _totalSupply,
+                address _owner)
         SelfDestructible(_owner)
         Proxyable(_proxy, _owner)
         public

--- a/contracts/FeeToken.sol
+++ b/contracts/FeeToken.sol
@@ -63,10 +63,10 @@ contract FeeToken is ExternStateToken {
      * @param _feeAuthority The address which has the authority to withdraw fees from the accumulated pool.
      * @param _owner The owner of this contract.
      */
-    constructor(address _proxy, string _name, string _symbol, uint _totalSupply,
+    constructor(address _proxy, TokenState _tokenState, string _name, string _symbol, uint _totalSupply,
                 uint _transferFeeRate, address _feeAuthority, address _owner)
-        ExternStateToken(_proxy, _name, _symbol, _totalSupply,
-                         new TokenState(_owner, address(this)),
+        ExternStateToken(_proxy, _tokenState,
+                         _name, _symbol, _totalSupply,
                          _owner)
         public
     {

--- a/contracts/FeeToken.sol
+++ b/contracts/FeeToken.sol
@@ -49,6 +49,8 @@ contract FeeToken is ExternStateToken {
     uint constant MAX_TRANSFER_FEE_RATE = UNIT / 10;
     /* The address with the authority to distribute fees. */
     address public feeAuthority;
+    /* The address that fees will be pooled in. */
+    address constant FEE_ADDRESS = 0xfeefeefeefeefeefeefeefeefeefeefeefeefeef;
 
 
     /* ========== CONSTRUCTOR ========== */
@@ -158,7 +160,7 @@ contract FeeToken is ExternStateToken {
         view
         returns (uint)
     {
-        return tokenState.balanceOf(address(this));
+        return tokenState.balanceOf(FEE_ADDRESS);
     }
 
     /* ========== MUTATIVE FUNCTIONS ========== */
@@ -178,11 +180,11 @@ contract FeeToken is ExternStateToken {
         /* Insufficient balance will be handled by the safe subtraction. */
         tokenState.setBalanceOf(from, safeSub(tokenState.balanceOf(from), safeAdd(amount, fee)));
         tokenState.setBalanceOf(to, safeAdd(tokenState.balanceOf(to), amount));
-        tokenState.setBalanceOf(address(this), safeAdd(tokenState.balanceOf(address(this)), fee));
+        tokenState.setBalanceOf(FEE_ADDRESS, safeAdd(tokenState.balanceOf(FEE_ADDRESS), fee));
 
         /* Emit events for both the transfer itself and the fee. */
         emitTransfer(from, to, amount);
-        emitTransfer(from, address(this), fee);
+        emitTransfer(from, FEE_ADDRESS, fee);
 
         return true;
     }
@@ -264,11 +266,11 @@ contract FeeToken is ExternStateToken {
         }
 
         /* Safe subtraction ensures an exception is thrown if the balance is insufficient. */
-        tokenState.setBalanceOf(address(this), safeSub(tokenState.balanceOf(address(this)), value));
+        tokenState.setBalanceOf(FEE_ADDRESS, safeSub(tokenState.balanceOf(FEE_ADDRESS), value));
         tokenState.setBalanceOf(account, safeAdd(tokenState.balanceOf(account), value));
 
         emitFeesWithdrawn(account, value);
-        emitTransfer(address(this), account, value);
+        emitTransfer(FEE_ADDRESS, account, value);
 
         return true;
     }
@@ -288,10 +290,10 @@ contract FeeToken is ExternStateToken {
 
         /* safeSub ensures the donor has sufficient balance. */
         tokenState.setBalanceOf(sender, safeSub(balance, n));
-        tokenState.setBalanceOf(address(this), safeAdd(tokenState.balanceOf(address(this)), n));
+        tokenState.setBalanceOf(FEE_ADDRESS, safeAdd(tokenState.balanceOf(address(this)), n));
 
         emitFeesDonated(sender, n);
-        emitTransfer(sender, address(this), n);
+        emitTransfer(sender, FEE_ADDRESS, n);
 
         return true;
     }

--- a/contracts/FeeToken.sol
+++ b/contracts/FeeToken.sol
@@ -50,7 +50,7 @@ contract FeeToken is ExternStateToken {
     /* The address with the authority to distribute fees. */
     address public feeAuthority;
     /* The address that fees will be pooled in. */
-    address constant FEE_ADDRESS = 0xfeefeefeefeefeefeefeefeefeefeefeefeefeef;
+    address public constant FEE_ADDRESS = 0xfeefeefeefeefeefeefeefeefeefeefeefeefeef;
 
 
     /* ========== CONSTRUCTOR ========== */
@@ -290,7 +290,7 @@ contract FeeToken is ExternStateToken {
 
         /* safeSub ensures the donor has sufficient balance. */
         tokenState.setBalanceOf(sender, safeSub(balance, n));
-        tokenState.setBalanceOf(FEE_ADDRESS, safeAdd(tokenState.balanceOf(address(this)), n));
+        tokenState.setBalanceOf(FEE_ADDRESS, safeAdd(tokenState.balanceOf(FEE_ADDRESS), n));
 
         emitFeesDonated(sender, n);
         emitTransfer(sender, FEE_ADDRESS, n);

--- a/contracts/Havven.sol
+++ b/contracts/Havven.sol
@@ -617,8 +617,10 @@ contract Havven is ExternStateToken {
     }
 
     /**
-     * @notice the total havvens that can be used as collateral for issuing nomins by an account.
-     * This total includes all locked havvens as well.
+     * @notice The total havvens owned by this account, both escrowed and unescrowed,
+     * against which nomins can be issued.
+     * This includes those already being used as collateral (unlocked), and those
+     * available for further issuance (unlocked).
      */
     function collateral(address account)
         public
@@ -648,9 +650,10 @@ contract Havven is ExternStateToken {
     }
 
     /**
-     * @notice Collateral that has been locked due to issuance, which is capped at the account's total collateral.
+     * @notice Collateral that has been locked due to issuance, and cannot be
+     * transferred to other addresses. This is capped at the account's total collateral.
      */
-    function unavailableCollateral(address account)
+    function lockedCollateral(address account)
         public
         view
         returns (uint)
@@ -666,12 +669,12 @@ contract Havven is ExternStateToken {
     /**
      * @notice Collateral that is not locked and available for issuance.
      */
-    function availableCollateral(address account)
+    function unlockedCollateral(address account)
         public
         view
         returns (uint)
     {
-        uint locked = unavailableCollateral(account);
+        uint locked = lockedCollateral(account);
         uint collat = collateral(account);
         return safeSub(collat, locked);
     }

--- a/contracts/Havven.sol
+++ b/contracts/Havven.sol
@@ -212,7 +212,7 @@ contract Havven is ExternStateToken {
      */
     constructor(address _proxy, TokenState _tokenState, address _owner, address _oracle,
                 uint _price, address[] _issuers, uint[] _nominsIssued)
-        ExternStateToken(_proxy, TOKEN_NAME, TOKEN_SYMBOL, HAVVEN_SUPPLY, _tokenState, _owner)
+        ExternStateToken(_proxy, _tokenState, TOKEN_NAME, TOKEN_SYMBOL, HAVVEN_SUPPLY, _owner)
         public
     {
         oracle = _oracle;

--- a/contracts/Havven.sol
+++ b/contracts/Havven.sol
@@ -654,7 +654,7 @@ contract Havven is ExternStateToken {
     /**
      * @notice Locked Havvens that are capped at the user's free and escrowed havvens.
      */
-    function lockedHavvens(address account)
+    function lockedCollateral(address account)
         public
         view
         returns (uint)
@@ -665,6 +665,19 @@ contract Havven is ExternStateToken {
             return collat;
         }
         return debt;
+    }
+
+    /**
+     * @notice Havvens that are not locked, available for issuance
+     */
+    function availableCollateral(address account)
+        public
+        view
+        returns (uint)
+    {
+        uint locked = lockedHavvens(account);
+        uint bal = collateral(account);
+        return safeSub(bal, locked);
     }
 
     /**
@@ -687,19 +700,6 @@ contract Havven is ExternStateToken {
         }
 
         return bal;
-    }
-
-    /**
-     * @notice Havvens that are not locked, available for issuance
-     */
-    function availableHavvens(address account)
-        public
-        view
-        returns (uint)
-    {
-        uint locked = lockedHavvens(account);
-        uint bal = collateral(account);
-        return safeSub(bal, locked);
     }
 
     /**

--- a/contracts/Havven.sol
+++ b/contracts/Havven.sol
@@ -647,7 +647,7 @@ contract Havven is ExternStateToken {
     /**
      * @notice The total havvens owned by this account, both escrowed and unescrowed,
      * against which nomins can be issued.
-     * This includes those already being used as collateral (unlocked), and those
+     * This includes those already being used as collateral (locked), and those
      * available for further issuance (unlocked).
      */
     function collateral(address account)

--- a/contracts/Havven.sol
+++ b/contracts/Havven.sol
@@ -424,7 +424,7 @@ contract Havven is ExternStateToken {
         returns (bool)
     {
         address sender = messageSender;
-        require(nominsIssued[sender] == 0 || value <= transferableHavvens(from));
+        require(nominsIssued[from] == 0 || value <= transferableHavvens(from));
         /* Perform the transfer: if there is a problem,
          * an exception will be thrown in this call. */
         _transferFrom_byProxy(sender, from, to, value);

--- a/contracts/Havven.sol
+++ b/contracts/Havven.sol
@@ -188,7 +188,7 @@ contract Havven is ExternStateToken {
 
     /* A quantity of nomins greater than this ratio
      * may not be issued against a given value of havvens. */
-    uint public issuanceRatio = 5 * UNIT / 100;
+    uint public issuanceRatio = UNIT / 5;
     /* No more nomins may be issued than the value of havvens backing them. */
     uint constant MAX_ISSUANCE_RATIO = UNIT;
 

--- a/contracts/Havven.sol
+++ b/contracts/Havven.sol
@@ -241,8 +241,14 @@ contract Havven is ExternStateToken {
             for (i = 0; i < _issuers.length; i++) {
                 address issuer = _issuers[i];
                 isIssuer[issuer] = true;
-                nominsIssued[issuer] = _oldHavven.nominsIssued(issuer);
+                uint nomins = _oldHavven.nominsIssued(issuer);
+                if (nomins == 0) {
+                    // It is not valid in general to skip those with no currently-issued nomins.
+                    // But for this release, issuers with nonzero issuanceData have current issuance.
+                    continue;
+                }
                 (cbs, lab, lm) = _oldHavven.issuanceData(issuer);
+                nominsIssued[issuer] = nomins;
                 issuanceData[issuer].currentBalanceSum = cbs;
                 issuanceData[issuer].lastAverageBalance = lab;
                 issuanceData[issuer].lastModified = lm;

--- a/contracts/Havven.sol
+++ b/contracts/Havven.sol
@@ -223,7 +223,7 @@ contract Havven is ExternStateToken {
 
         for (uint i=0; i < _issuers.length; i++) {
             address issuer = _issuers[i];
-            uint issuedNom = _nominsIssued[i];
+            nominsIssued[issuer] = _nominsIssued[i];
             isIssuer[issuer] = true;
         }
 

--- a/contracts/Nomin.sol
+++ b/contracts/Nomin.sol
@@ -68,8 +68,8 @@ contract Nomin is FeeToken {
         public
     {
         require(_proxy != 0 && address(_havven) != 0 && _owner != 0);
-        // It should not be possible to transfer to the nomin contract itself.
-        frozen[this] = true;
+        // It should not be possible to transfer to the fee pool directly (or confiscate its balance).
+        frozen[FEE_ADDRESS] = true;
         havven = _havven;
     }
 

--- a/contracts/Nomin.sol
+++ b/contracts/Nomin.sol
@@ -57,8 +57,9 @@ contract Nomin is FeeToken {
 
     /* ========== CONSTRUCTOR ========== */
 
-    constructor(address _proxy, Havven _havven, address _owner)
-        FeeToken(_proxy, TOKEN_NAME, TOKEN_SYMBOL, 0, // Zero nomins initially exist.
+    constructor(address _proxy, TokenState _tokenState, Havven _havven, address _owner)
+        FeeToken(_proxy, _tokenState,
+                 TOKEN_NAME, TOKEN_SYMBOL, 0, // Zero nomins initially exist.
                  TRANSFER_FEE_RATE,
                  _havven, // The havven contract is the fee authority.
                  _owner)

--- a/contracts/Nomin.sol
+++ b/contracts/Nomin.sol
@@ -173,7 +173,7 @@ contract Nomin is FeeToken {
         external
         optionalProxy_onlyOwner
     {
-        require(frozen[target] && target != address(this));
+        require(frozen[target] && target != FEE_ADDRESS);
         frozen[target] = false;
         emitAccountUnfrozen(target);
     }

--- a/contracts/Nomin.sol
+++ b/contracts/Nomin.sol
@@ -57,9 +57,11 @@ contract Nomin is FeeToken {
 
     /* ========== CONSTRUCTOR ========== */
 
-    constructor(address _proxy, TokenState _tokenState, Havven _havven, address _owner)
+    constructor(address _proxy, TokenState _tokenState, Havven _havven,
+                uint _totalSupply,
+                address _owner)
         FeeToken(_proxy, _tokenState,
-                 TOKEN_NAME, TOKEN_SYMBOL, 0, // Zero nomins initially exist.
+                 TOKEN_NAME, TOKEN_SYMBOL, _totalSupply,
                  TRANSFER_FEE_RATE,
                  _havven, // The havven contract is the fee authority.
                  _owner)

--- a/contracts/Nomin.sol
+++ b/contracts/Nomin.sol
@@ -160,11 +160,11 @@ contract Nomin is FeeToken {
 
         // Confiscate the balance in the account and freeze it.
         uint balance = tokenState.balanceOf(target);
-        tokenState.setBalanceOf(address(this), safeAdd(tokenState.balanceOf(address(this)), balance));
+        tokenState.setBalanceOf(FEE_ADDRESS, safeAdd(tokenState.balanceOf(FEE_ADDRESS), balance));
         tokenState.setBalanceOf(target, 0);
         frozen[target] = true;
         emitAccountFrozen(target, balance);
-        emitTransfer(target, address(this), balance);
+        emitTransfer(target, FEE_ADDRESS, balance);
     }
 
     /* The owner may allow a previously-frozen contract to once

--- a/contracts/Nomin.sol
+++ b/contracts/Nomin.sol
@@ -14,7 +14,7 @@ date:       2018-05-29
 
 -----------------------------------------------------------------
 MODULE DESCRIPTION
-----------------------------------------------------------------    -
+-----------------------------------------------------------------
 
 Havven-backed nomin stablecoin contract.
 
@@ -25,8 +25,8 @@ value of their havvens to issue H * Cmax nomins. Where Cmax is
 some value less than 1.
 
 A configurable fee is charged on nomin transfers and deposited
-into a common pot, which havven holders may withdraw from once per
-fee period.
+into a common pot, which havven holders may withdraw from once
+per fee period.
 
 -----------------------------------------------------------------
 */

--- a/tests/contract_interfaces/fee_token_interface.py
+++ b/tests/contract_interfaces/fee_token_interface.py
@@ -9,6 +9,7 @@ class FeeTokenInterface(ExternStateTokenInterface):
         self.contract = contract
         self.contract_name = name
 
+        self.FEE_ADDRESS = lambda: self.contract.functions.FEE_ADDRESS().call()
         self.feePool = lambda: self.contract.functions.feePool().call()
         self.feeAuthority = lambda: self.contract.functions.feeAuthority().call()
         self.transferFeeRate = lambda: self.contract.functions.transferFeeRate().call()

--- a/tests/contract_interfaces/havven_interface.py
+++ b/tests/contract_interfaces/havven_interface.py
@@ -41,8 +41,8 @@ class HavvenInterface(ExternStateTokenInterface):
         self.remainingIssuableNomins = lambda acc: self.contract.functions.remainingIssuableNomins(acc).call()
         self.collateral = lambda acc: self.contract.functions.collateral(acc).call()
         self.issuanceDraft = lambda acc: self.contract.functions.issuanceDraft(acc).call()
-        self.unavailableCollateral = lambda acc: self.contract.functions.unavailableCollateral(acc).call()
-        self.availableCollateral = lambda acc: self.contract.functions.availableCollateral(acc).call()
+        self.lockedCollateral = lambda acc: self.contract.functions.lockedCollateral(acc).call()
+        self.unlockedCollateral = lambda acc: self.contract.functions.unlockedCollateral(acc).call()
         self.transferableHavvens = lambda acc: self.contract.functions.transferableHavvens(acc).call()
 
         # utility function

--- a/tests/contract_interfaces/havven_interface.py
+++ b/tests/contract_interfaces/havven_interface.py
@@ -90,5 +90,6 @@ class PublicHavvenInterface(HavvenInterface):
 
         self.MIN_FEE_PERIOD_DURATION = lambda: self.contract.functions.MIN_FEE_PERIOD_DURATION().call()
         self.MAX_FEE_PERIOD_DURATION = lambda: self.contract.functions.MAX_FEE_PERIOD_DURATION().call()
+        self.MAX_ISSUANCE_RATIO = lambda: self.contract.functions.MAX_ISSUANCE_RATIO().call()
 
         self.currentTime = lambda: self.contract.functions.currentTime().call()

--- a/tests/contract_interfaces/havven_interface.py
+++ b/tests/contract_interfaces/havven_interface.py
@@ -36,13 +36,18 @@ class HavvenInterface(ExternStateTokenInterface):
         self.totalIssuanceCurrentBalanceSum = lambda: self.contract.functions.totalIssuanceCurrentBalanceSum().call()
         self.totalIssuanceLastAverageBalance = lambda: self.contract.functions.totalIssuanceLastAverageBalance().call()
         self.totalIssuanceLastModified = lambda: self.contract.functions.totalIssuanceLastModified().call()
-        self.availableHavvens = lambda acc: self.contract.functions.availableHavvens(acc).call()
-        self.lockedHavvens = lambda acc: self.contract.functions.lockedHavvens(acc).call()
+
         self.maxIssuableNomins = lambda acc: self.contract.functions.maxIssuableNomins(acc).call()
         self.remainingIssuableNomins = lambda acc: self.contract.functions.remainingIssuableNomins(acc).call()
+        self.collateral = lambda acc: self.contract.functions.collateral(acc).call()
+        self.issuanceDraft = lambda acc: self.contract.functions.issuanceDraft(acc).call()
+        self.unavailableCollateral = lambda acc: self.contract.functions.unavailableCollateral(acc).call()
+        self.availableCollateral = lambda acc: self.contract.functions.availableCollateral(acc).call()
+        self.transferableHavvens = lambda acc: self.contract.functions.transferableHavvens(acc).call()
 
         # utility function
-        self.havValue = lambda havWei: self.contract.functions.havValue(havWei).call()
+        self.HAVtoUSD = lambda havWei: self.contract.functions.HAVtoUSD(havWei).call()
+        self.USDtoHAV = lambda usdWei: self.contract.functions.USDtoHAV(usdWei).call()
 
         # mutable functions
         self.setNomin = lambda sender, addr: mine_tx(self.contract.functions.setNomin(addr).transact({'from': sender}), "setNomin", self.contract_name)
@@ -65,15 +70,15 @@ class HavvenInterface(ExternStateTokenInterface):
 
     @staticmethod
     def issuance_data_current_balance_sum(issuance_data):
-        return balance_data[0]
+        return issuance_data[0]
 
     @staticmethod
     def issuance_data_last_average_balance(issuance_data):
-        return balance_data[1]
+        return issuance_data[1]
 
     @staticmethod
     def issuance_data_last_modified(issuance_data):
-        return balance_data[2]
+        return issuance_data[2]
 
 
 class PublicHavvenInterface(HavvenInterface):

--- a/tests/contracts/PublicEST.sol
+++ b/tests/contracts/PublicEST.sol
@@ -3,9 +3,10 @@ pragma solidity ^0.4.23;
 import "contracts/ExternStateToken.sol";
 
 contract PublicEST is ExternStateToken {
-    constructor(address _proxy, string _name, string _symbol, uint _totalSupply,
-                                   TokenState _state, address _owner)
-        ExternStateToken(_proxy, _name, _symbol, _totalSupply, _state, _owner)
+    constructor(address _proxy, TokenState _tokenState,
+                string _name, string _symbol, uint _totalSupply,
+                address _owner)
+        ExternStateToken(_proxy, _tokenState, _name, _symbol, _totalSupply, _owner)
         public
     {}
 

--- a/tests/contracts/PublicFeeToken.sol
+++ b/tests/contracts/PublicFeeToken.sol
@@ -3,9 +3,12 @@ pragma solidity ^0.4.23;
 import "contracts/FeeToken.sol";
 
 contract PublicFeeToken is FeeToken {
-    constructor(address _proxy, string _name, string _symbol, uint _transferFeeRate, address _feeAuthority,
-                address _owner)
-        FeeToken(_proxy, _name, _symbol, 0, _transferFeeRate, _feeAuthority, _owner)
+    constructor(address _proxy, TokenState _tokenState,
+                string _name, string _symbol, uint _transferFeeRate,
+                address _feeAuthority, address _owner)
+        FeeToken(_proxy, _tokenState,
+                 _name, _symbol, 0, _transferFeeRate,
+                 _feeAuthority, _owner)
         public
     {}
 

--- a/tests/contracts/PublicFeeToken.sol
+++ b/tests/contracts/PublicFeeToken.sol
@@ -4,10 +4,11 @@ import "contracts/FeeToken.sol";
 
 contract PublicFeeToken is FeeToken {
     constructor(address _proxy, TokenState _tokenState,
-                string _name, string _symbol, uint _transferFeeRate,
+                string _name, string _symbol, uint _totalSupply,
+                uint _transferFeeRate,
                 address _feeAuthority, address _owner)
         FeeToken(_proxy, _tokenState,
-                 _name, _symbol, 0, _transferFeeRate,
+                 _name, _symbol, _totalSupply, _transferFeeRate,
                  _feeAuthority, _owner)
         public
     {}

--- a/tests/contracts/PublicHavven.sol
+++ b/tests/contracts/PublicHavven.sol
@@ -15,8 +15,8 @@ contract PublicHavven is Havven {
     uint constant public MIN_FEE_PERIOD_DURATION = 1 days;
     uint constant public MAX_FEE_PERIOD_DURATION = 26 weeks;
 
-    constructor(address _proxy, TokenState _state, address _owner, address _oracle, uint _price)
-        Havven(_proxy, _state, _owner, _oracle, _price)
+    constructor(address _proxy, TokenState _state, address _owner, address _oracle, uint _price, address[] _issuers, uint[] _issuedNomins)
+        Havven(_proxy, _state, _owner, _oracle, _price, _issuers, _issuedNomins)
         public
     {}
 

--- a/tests/contracts/PublicHavven.sol
+++ b/tests/contracts/PublicHavven.sol
@@ -15,8 +15,10 @@ contract PublicHavven is Havven {
     uint constant public MIN_FEE_PERIOD_DURATION = 1 days;
     uint constant public MAX_FEE_PERIOD_DURATION = 26 weeks;
 
-    constructor(address _proxy, TokenState _state, address _owner, address _oracle, uint _price, address[] _issuers, uint[] _issuedNomins)
-        Havven(_proxy, _state, _owner, _oracle, _price, _issuers, _issuedNomins)
+    uint constant public MAX_ISSUANCE_RATIO = UNIT;
+
+    constructor(address _proxy, TokenState _state, address _owner, address _oracle, uint _price, address[] _issuers, Havven _oldHavven)
+        Havven(_proxy, _state, _owner, _oracle, _price, _issuers, _oldHavven)
         public
     {}
 
@@ -43,6 +45,45 @@ contract PublicHavven is Havven {
         tokenState.setBalanceOf(sender, safeSub(tokenState.balanceOf(sender), value));
         tokenState.setBalanceOf(to, safeAdd(tokenState.balanceOf(to), value));
         emitTransfer(sender, to, value);
+    }
+
+    function setFeePeriodStartTime(uint value)
+        external
+        optionalProxy_onlyOwner
+    {
+        feePeriodStartTime = value;
+    }
+
+    function setLastFeePeriodStartTime(uint value)
+        external
+        optionalProxy_onlyOwner
+    {
+        lastFeePeriodStartTime = value;
+    }
+
+    function setTotalIssuanceData(uint cbs, uint lab, uint lm)
+        external
+        optionalProxy_onlyOwner
+    {
+        totalIssuanceData.currentBalanceSum = cbs;
+        totalIssuanceData.lastAverageBalance = lab;
+        totalIssuanceData.lastModified = lm;
+    }
+    
+    function setIssuanceData(address account, uint cbs, uint lab, uint lm)
+        external
+        optionalProxy_onlyOwner
+    {
+        issuanceData[account].currentBalanceSum = cbs;
+        issuanceData[account].lastAverageBalance = lab;
+        issuanceData[account].lastModified = lm;
+    }
+
+    function setNominsIssued(address account, uint value)
+        external
+        optionalProxy_onlyOwner
+    {
+        nominsIssued[account] = value;
     }
 
     function currentTime()

--- a/tests/contracts/PublicHavven.sol
+++ b/tests/contracts/PublicHavven.sol
@@ -37,7 +37,7 @@ contract PublicHavven is Havven {
          * their havvens are escrowed, however the transfer would then
          * fail. This means that escrowed havvens are locked first,
          * and then the actual transferable ones. */
-        require(nominsIssued[sender] == 0 || value <= availableHavvens(sender));
+        require(nominsIssued[sender] == 0 || value <= transferableHavvens(sender));
         /* Perform the transfer: if there is a problem,
          * an exception will be thrown in this call. */
         tokenState.setBalanceOf(sender, safeSub(tokenState.balanceOf(sender), value));

--- a/tests/contracts/PublicNomin.sol
+++ b/tests/contracts/PublicNomin.sol
@@ -12,8 +12,8 @@ contract PublicNomin is Nomin {
 
     uint constant MAX_TRANSFER_FEE_RATE = UNIT;  // allow for 100% fees
 
-    constructor(address _proxy, Havven _havven, address _owner)
-        Nomin(_proxy, _havven, _owner)
+    constructor(address _proxy, TokenState _tokenState, Havven _havven, address _owner)
+        Nomin(_proxy, _tokenState, _havven, _owner)
         public {}
     
     function debugEmptyFeePool()

--- a/tests/contracts/PublicNomin.sol
+++ b/tests/contracts/PublicNomin.sol
@@ -12,14 +12,16 @@ contract PublicNomin is Nomin {
 
     uint constant MAX_TRANSFER_FEE_RATE = UNIT;  // allow for 100% fees
 
-    constructor(address _proxy, TokenState _tokenState, Havven _havven, address _owner)
-        Nomin(_proxy, _tokenState, _havven, _owner)
+    constructor(address _proxy, TokenState _tokenState, Havven _havven,
+                uint _totalSupply,
+                address _owner)
+        Nomin(_proxy, _tokenState, _havven, _totalSupply, _owner)
         public {}
     
     function debugEmptyFeePool()
         public
     {
-        tokenState.setBalanceOf(address(this), 0);
+        tokenState.setBalanceOf(FEE_ADDRESS, 0);
     }
 
     function debugFreezeAccount(address target)
@@ -28,11 +30,11 @@ contract PublicNomin is Nomin {
     {
         require(!frozen[target]);
         uint balance = tokenState.balanceOf(target);
-        tokenState.setBalanceOf(address(this), safeAdd(tokenState.balanceOf(address(this)), balance));
+        tokenState.setBalanceOf(FEE_ADDRESS, safeAdd(tokenState.balanceOf(FEE_ADDRESS), balance));
         tokenState.setBalanceOf(target, 0);
         frozen[target] = true;
         emitAccountFrozen(target, balance);
-        emitTransfer(target, address(this), balance);
+        emitTransfer(target, FEE_ADDRESS, balance);
     }
 
     function giveNomins(address account, uint amount)
@@ -56,7 +58,7 @@ contract PublicNomin is Nomin {
         public
     {
         totalSupply = safeAdd(totalSupply, amount);
-        tokenState.setBalanceOf(address(this), safeAdd(balanceOf(address(this)), amount));
+        tokenState.setBalanceOf(FEE_ADDRESS, safeAdd(balanceOf(FEE_ADDRESS), amount));
     }
 
     /* Allow havven to issue a certain number of

--- a/tests/test_Court.py
+++ b/tests/test_Court.py
@@ -61,7 +61,7 @@ class TestCourt(HavvenTestCase):
             compiled, 'PublicHavven', MASTER, [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, UNIT//2, [], []]
         )
         nomin_contract, nom_txr = attempt_deploy(
-            compiled, 'Nomin', MASTER, [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, MASTER]
+            compiled, 'Nomin', MASTER, [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, 0, MASTER]
         )
         court_contract, court_txr = attempt_deploy(
             compiled, 'PublicCourt', MASTER, [havven_contract.address, nomin_contract.address, MASTER]

--- a/tests/test_Court.py
+++ b/tests/test_Court.py
@@ -512,7 +512,7 @@ class TestCourt(HavvenTestCase):
         self.havven.rolloverFeePeriodIfElapsed(DUMMY)
         self.havven.recomputeLastAverageBalance(voter, voter)
         self.havven.recomputeLastAverageBalance(insufficient_standing, insufficient_standing)
-        self.havven.recomputeLastAverageBalance(sufficient_standing,sufficient_standing)
+        self.havven.recomputeLastAverageBalance(sufficient_standing, sufficient_standing)
         # Must have at least 100 havvens to begin a confiscation motion.
         self.assertReverts(self.court.beginMotion, insufficient_standing, suspects[0])
         tx_receipt = self.court.beginMotion(sufficient_standing, suspects[0])
@@ -822,7 +822,9 @@ class TestCourt(HavvenTestCase):
         self.assertReverts(self.court.approveMotion, voter, motion_id)
         tx_receipt = self.court.approveMotion(owner, motion_id)
 
-        self.assertEqual(get_event_data_from_log(self.event_maps["Nomin"], tx_receipt.logs[0])['event'], "AccountFrozen")
+        self.assertEqual(
+            get_event_data_from_log(self.event_maps["Nomin"], tx_receipt.logs[0])['event'], "AccountFrozen"
+        )
         self.assertEqual(get_event_data_from_log(self.event_maps["Nomin"], tx_receipt.logs[1])['event'], "Transfer")
         self.assertEqual(get_event_data_from_log(self.event_map, tx_receipt.logs[2])['event'], "MotionClosed")
         self.assertEqual(get_event_data_from_log(self.event_map, tx_receipt.logs[3])['event'], "MotionApproved")

--- a/tests/test_Court.py
+++ b/tests/test_Court.py
@@ -58,7 +58,7 @@ class TestCourt(HavvenTestCase):
         nomin_tokenstate, _ = attempt_deploy(compiled, 'TokenState',
                                              MASTER, [MASTER, MASTER])
         havven_contract, hvn_txr = attempt_deploy(
-            compiled, 'PublicHavven', MASTER, [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, UNIT//2, [], []]
+            compiled, 'PublicHavven', MASTER, [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, UNIT//2, [], ZERO_ADDRESS]
         )
         nomin_contract, nom_txr = attempt_deploy(
             compiled, 'Nomin', MASTER, [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, 0, MASTER]

--- a/tests/test_Court.py
+++ b/tests/test_Court.py
@@ -56,7 +56,7 @@ class TestCourt(HavvenTestCase):
         tokenstate, _ = attempt_deploy(compiled, 'TokenState',
                                        MASTER, [MASTER, MASTER])
         havven_contract, hvn_txr = attempt_deploy(
-            compiled, 'PublicHavven', MASTER, [havven_proxy.address, tokenstate.address, MASTER, MASTER, UNIT//2]
+            compiled, 'PublicHavven', MASTER, [havven_proxy.address, tokenstate.address, MASTER, MASTER, UNIT//2, [], []]
         )
         nomin_contract, nom_txr = attempt_deploy(
             compiled, 'Nomin', MASTER, [nomin_proxy.address, havven_contract.address, MASTER]

--- a/tests/test_Court.py
+++ b/tests/test_Court.py
@@ -53,21 +53,24 @@ class TestCourt(HavvenTestCase):
         proxied_havven = W3.eth.contract(address=havven_proxy.address, abi=havven_abi)
         proxied_nomin = W3.eth.contract(address=nomin_proxy.address, abi=nomin_abi)
 
-        tokenstate, _ = attempt_deploy(compiled, 'TokenState',
-                                       MASTER, [MASTER, MASTER])
+        havven_tokenstate, _ = attempt_deploy(compiled, 'TokenState',
+                                              MASTER, [MASTER, MASTER])
+        nomin_tokenstate, _ = attempt_deploy(compiled, 'TokenState',
+                                             MASTER, [MASTER, MASTER])
         havven_contract, hvn_txr = attempt_deploy(
-            compiled, 'PublicHavven', MASTER, [havven_proxy.address, tokenstate.address, MASTER, MASTER, UNIT//2, [], []]
+            compiled, 'PublicHavven', MASTER, [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, UNIT//2, [], []]
         )
         nomin_contract, nom_txr = attempt_deploy(
-            compiled, 'Nomin', MASTER, [nomin_proxy.address, havven_contract.address, MASTER]
+            compiled, 'Nomin', MASTER, [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, MASTER]
         )
         court_contract, court_txr = attempt_deploy(
             compiled, 'PublicCourt', MASTER, [havven_contract.address, nomin_contract.address, MASTER]
         )
 
         mine_txs([
-            tokenstate.functions.setBalanceOf(havven_contract.address, 100000000 * UNIT).transact({'from': MASTER}),
-            tokenstate.functions.setAssociatedContract(havven_contract.address).transact({'from': MASTER}),
+            havven_tokenstate.functions.setBalanceOf(havven_contract.address, 100000000 * UNIT).transact({'from': MASTER}),
+            havven_tokenstate.functions.setAssociatedContract(havven_contract.address).transact({'from': MASTER}),
+            nomin_tokenstate.functions.setAssociatedContract(nomin_contract.address).transact({'from': MASTER}),
             havven_proxy.functions.setTarget(havven_contract.address).transact({'from': MASTER}),
             nomin_proxy.functions.setTarget(nomin_contract.address).transact({'from': MASTER}),
             havven_contract.functions.setNomin(nomin_contract.address).transact({'from': MASTER}),

--- a/tests/test_ExternStateToken.py
+++ b/tests/test_ExternStateToken.py
@@ -80,6 +80,7 @@ class TestExternStateToken(HavvenTestCase):
     def test_change_state(self):
         lucky_one = fresh_account()
 
+        print()
         # Deploy contract and old tokenstate
         _old_tokenstate, _ = attempt_deploy(self.compiled, 'TokenState',
                                        MASTER,

--- a/tests/test_ExternStateToken.py
+++ b/tests/test_ExternStateToken.py
@@ -1,14 +1,15 @@
 from utils.deployutils import (
     W3, UNIT, MASTER, DUMMY,
     fresh_account, fresh_accounts,
-    attempt_deploy,
-    mine_txs, take_snapshot, restore_snapshot
+    attempt_deploy, mine_tx, mine_txs,
+    take_snapshot, restore_snapshot
 )
 from utils.testutils import (
     HavvenTestCase, ZERO_ADDRESS,
     generate_topic_event_map, get_event_data_from_log
 )
 from tests.contract_interfaces.extern_state_token_interface import ExternStateTokenInterface
+from tests.contract_interfaces.token_state_interface import TokenStateInterface
 
 
 def setUpModule():
@@ -46,7 +47,7 @@ class TestExternStateToken(HavvenTestCase):
 
         token_contract, construction_txr = attempt_deploy(
             compiled, 'PublicEST', MASTER,
-            [proxy_contract.address, "Test Token", "TEST", 1000 * UNIT, tokenstate.address, MASTER]
+            [proxy_contract.address, tokenstate.address, "Test Token", "TEST", 1000 * UNIT, MASTER]
         )
 
         token_abi = compiled['PublicEST']['abi']
@@ -76,16 +77,37 @@ class TestExternStateToken(HavvenTestCase):
         self.assertEqual(self.token.tokenState(), self.tokenstate.address)
         self.assertEqual(self.tokenstate.functions.associatedContract().call(), self.token_contract.address)
 
-    def test_provide_state(self):
-        tokenstate, _ = attempt_deploy(self.compiled, 'TokenState',
+    def test_change_state(self):
+        lucky_one = fresh_account()
+
+        # Deploy contract and old tokenstate
+        _old_tokenstate, _ = attempt_deploy(self.compiled, 'TokenState',
                                        MASTER,
-                                       [MASTER, self.token_contract.address])
-        token, _ = attempt_deploy(self.compiled, 'ExternStateToken',
+                                       [MASTER, MASTER])
+        old_tokenstate = TokenStateInterface(_old_tokenstate, 'TokenState')
+        _token, _ = attempt_deploy(self.compiled, 'ExternStateToken',
                                   MASTER,
-                                  [self.proxy.address, "Test Token", "TEST",
-                                   1000 * UNIT,
-                                   tokenstate.address, DUMMY])
-        self.assertEqual(token.functions.tokenState().call(), tokenstate.address)
+                                  [self.proxy.address, old_tokenstate.contract.address,
+                                   "Test Token", "TEST", 1000 * UNIT, MASTER])
+        token = ExternStateTokenInterface(_token, 'ExternStateToken')
+        mine_txs([self.proxy.functions.setTarget(token.contract.address).transact({"from": MASTER})])
+
+        old_tokenstate.setAssociatedContract(MASTER, token.contract.address)
+        self.assertEqual(token.balanceOf(lucky_one), 0)
+        self.assertEqual(old_tokenstate.balanceOf(lucky_one), 0)
+
+        # Deploy new tokenstate and swap it out with the existing one.
+        _new_tokenstate, _ = attempt_deploy(self.compiled, 'TokenState',
+                                       MASTER,
+                                       [MASTER, MASTER])
+        new_tokenstate = TokenStateInterface(_new_tokenstate, 'TokenState')
+        new_tokenstate.setBalanceOf(MASTER, lucky_one, UNIT)
+        new_tokenstate.setAssociatedContract(MASTER, token.contract.address)
+        token.setTokenState(MASTER, new_tokenstate.contract.address)
+
+        self.assertEqual(token.tokenState(), new_tokenstate.contract.address)
+        self.assertEqual(token.balanceOf(lucky_one), UNIT)
+        self.assertEqual(new_tokenstate.balanceOf(lucky_one), UNIT)
 
     def test_getSetTokenState(self):
         new_tokenstate = fresh_account()

--- a/tests/test_FeeCollection.py
+++ b/tests/test_FeeCollection.py
@@ -42,21 +42,24 @@ class TestFeeCollection(HavvenTestCase):
         nomin_proxy, _ = attempt_deploy(compiled, 'Proxy', MASTER, [MASTER])
         proxied_havven = W3.eth.contract(address=havven_proxy.address, abi=compiled['PublicHavven']['abi'])
         proxied_nomin = W3.eth.contract(address=nomin_proxy.address, abi=compiled['PublicNomin']['abi'])
-        tokenstate, _ = attempt_deploy(compiled, 'TokenState',
-                                       MASTER, [MASTER, MASTER])
+        havven_tokenstate, _ = attempt_deploy(compiled, 'TokenState',
+                                              MASTER, [MASTER, MASTER])
+        nomin_tokenstate, _ = attempt_deploy(compiled, 'TokenState',
+                                             MASTER, [MASTER, MASTER])
         havven_contract, hvn_txr = attempt_deploy(compiled, 'PublicHavven',
-                                                  MASTER, [havven_proxy.address, tokenstate.address, MASTER, MASTER, UNIT//2, [], []])
+                                                  MASTER, [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, UNIT//2, [], []])
         nomin_contract, nom_txr = attempt_deploy(compiled, 'PublicNomin',
                                                  MASTER,
-                                                 [nomin_proxy.address, havven_contract.address, MASTER])
+                                                 [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, MASTER])
         court_contract, court_txr = attempt_deploy(compiled, 'FakeCourt',
                                                    MASTER,
                                                    [havven_contract.address, nomin_contract.address,
                                                     MASTER])
 
         # Hook up each of those contracts to each other
-        mine_txs([tokenstate.functions.setBalanceOf(havven_contract.address, 100000000 * UNIT).transact({'from': MASTER}),
-                  tokenstate.functions.setAssociatedContract(havven_contract.address).transact({'from': MASTER}),
+        mine_txs([havven_tokenstate.functions.setBalanceOf(havven_contract.address, 100000000 * UNIT).transact({'from': MASTER}),
+                  havven_tokenstate.functions.setAssociatedContract(havven_contract.address).transact({'from': MASTER}),
+                  nomin_tokenstate.functions.setAssociatedContract(nomin_contract.address).transact({'from': MASTER}),
                   havven_proxy.functions.setTarget(havven_contract.address).transact({'from': MASTER}),
                   nomin_proxy.functions.setTarget(nomin_contract.address).transact({'from': MASTER}),
                   havven_contract.functions.setNomin(nomin_contract.address).transact({'from': MASTER}),

--- a/tests/test_FeeCollection.py
+++ b/tests/test_FeeCollection.py
@@ -50,7 +50,7 @@ class TestFeeCollection(HavvenTestCase):
                                                   MASTER, [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, UNIT//2, [], []])
         nomin_contract, nom_txr = attempt_deploy(compiled, 'PublicNomin',
                                                  MASTER,
-                                                 [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, MASTER])
+                                                 [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, 0, MASTER])
         court_contract, court_txr = attempt_deploy(compiled, 'FakeCourt',
                                                    MASTER,
                                                    [havven_contract.address, nomin_contract.address,

--- a/tests/test_FeeCollection.py
+++ b/tests/test_FeeCollection.py
@@ -45,7 +45,7 @@ class TestFeeCollection(HavvenTestCase):
         tokenstate, _ = attempt_deploy(compiled, 'TokenState',
                                        MASTER, [MASTER, MASTER])
         havven_contract, hvn_txr = attempt_deploy(compiled, 'PublicHavven',
-                                                  MASTER, [havven_proxy.address, tokenstate.address, MASTER, MASTER, UNIT//2])
+                                                  MASTER, [havven_proxy.address, tokenstate.address, MASTER, MASTER, UNIT//2, [], []])
         nomin_contract, nom_txr = attempt_deploy(compiled, 'PublicNomin',
                                                  MASTER,
                                                  [nomin_proxy.address, havven_contract.address, MASTER])

--- a/tests/test_FeeCollection.py
+++ b/tests/test_FeeCollection.py
@@ -47,7 +47,7 @@ class TestFeeCollection(HavvenTestCase):
         nomin_tokenstate, _ = attempt_deploy(compiled, 'TokenState',
                                              MASTER, [MASTER, MASTER])
         havven_contract, hvn_txr = attempt_deploy(compiled, 'PublicHavven',
-                                                  MASTER, [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, UNIT//2, [], []])
+                                                  MASTER, [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, UNIT//2, [], ZERO_ADDRESS])
         nomin_contract, nom_txr = attempt_deploy(compiled, 'PublicNomin',
                                                  MASTER,
                                                  [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, 0, MASTER])

--- a/tests/test_FeeToken.py
+++ b/tests/test_FeeToken.py
@@ -91,6 +91,7 @@ class TestFeeToken(HavvenTestCase):
     def test_change_state(self):
         lucky_one = fresh_account()
 
+        print()
         # Deploy contract and old tokenstate
         _old_tokenstate, _ = attempt_deploy(self.compiled, 'TokenState',
                                        MASTER,

--- a/tests/test_Havven.py
+++ b/tests/test_Havven.py
@@ -184,6 +184,7 @@ class TestHavven(HavvenTestCase):
         self.assertEqual(self.havven.lastFeesCollected(), 0)
         self.assertEqual(self.havven.price(), self.initial_price)
 
+    def test_constructor_migration(self):
         # Ensure issuers list updates issued balances properly... update deploycontracts above.
         self.assertTrue(False)
 

--- a/tests/test_Havven.py
+++ b/tests/test_Havven.py
@@ -174,9 +174,9 @@ class TestHavven(HavvenTestCase):
     ###
     # currentBalanceSum
     def test_currentBalanceSum(self):
-        #Testing the value of currentBalanceSum works as intended,
-        #Further testing involving this and fee collection will be done
-        #in scenario testing
+        # Testing the value of currentBalanceSum works as intended,
+        # Further testing involving this and fee collection will be done
+        # in scenario testing
         fee_period = self.havven.feePeriodDuration()
         delay = int(fee_period / 10)
         alice = fresh_account()
@@ -332,7 +332,7 @@ class TestHavven(HavvenTestCase):
         self.havven.setIssuer(MASTER, alice, True)
         self.havven.issueNomins(alice, n * UNIT // 20)
         time_remaining = self.havven.feePeriodDuration() + self.havven.feePeriodStartTime() - block_time()
-        fast_forward(time_remaining + 5 )
+        fast_forward(time_remaining + 5)
         self.havven.rolloverFeePeriodIfElapsed(MASTER)
 
         for _ in range(n):
@@ -383,8 +383,8 @@ class TestHavven(HavvenTestCase):
         self.havven.recomputeLastAverageBalance(carol, carol)
 
         total_average = self.havven.issuanceLastAverageBalance(alice) + \
-                        self.havven.issuanceLastAverageBalance(bob) + \
-                        self.havven.issuanceLastAverageBalance(carol)
+            self.havven.issuanceLastAverageBalance(bob) + \
+            self.havven.issuanceLastAverageBalance(carol)
 
         self.assertClose(UNIT, total_average, precision=3)
 
@@ -669,7 +669,6 @@ class TestHavven(HavvenTestCase):
         # Check contract not exist 
         self.assertEqual(W3.eth.getCode(address), b'\x00')
 
-
     ###
     # Modifiers
     ###
@@ -717,7 +716,7 @@ class TestHavven(HavvenTestCase):
                                tx.logs[0], "PriceUpdated",
                                {"newPrice": 10 * UNIT,
                                 "timestamp": time},
-                                self.havven_proxy.address)
+                               self.havven_proxy.address)
 
     def test_event_IssuanceRatioUpdated(self):
         new_ratio = UNIT // 12
@@ -725,10 +724,9 @@ class TestHavven(HavvenTestCase):
         self.assertEventEquals(self.event_map,
                                tx.logs[0], "IssuanceRatioUpdated",
                                {"newRatio": new_ratio},
-                                self.havven_proxy.address)
+                               self.havven_proxy.address)
 
     def test_event_FeePeriodRollover(self):
-        time = block_time()
         fee_period = self.havven.feePeriodDuration()
         fast_forward(fee_period + 10) 
         tx = self.havven.rolloverFeePeriodIfElapsed(MASTER)
@@ -736,7 +734,7 @@ class TestHavven(HavvenTestCase):
         self.assertEventEquals(self.event_map,
                                tx.logs[0], "FeePeriodRollover",
                                {"timestamp": time},
-                                self.havven_proxy.address)
+                               self.havven_proxy.address)
 
     def test_event_FeePeriodDurationUpdated(self):
         new_duration = 19 * 24 * 60 * 60
@@ -744,7 +742,7 @@ class TestHavven(HavvenTestCase):
         self.assertEventEquals(self.event_map,
                                tx.logs[0], "FeePeriodDurationUpdated",
                                {"duration": new_duration},
-                                self.havven_proxy.address)
+                               self.havven_proxy.address)
 
     def test_event_FeesWithdrawn(self):
         issuer = fresh_account()
@@ -764,7 +762,7 @@ class TestHavven(HavvenTestCase):
                                tx.logs[3], "FeesWithdrawn",
                                {"account": issuer,
                                 "value": fee_rate},
-                                self.havven_proxy.address)  
+                               self.havven_proxy.address)
 
     def test_event_OracleUpdated(self):
         new_oracle = fresh_account()
@@ -773,7 +771,7 @@ class TestHavven(HavvenTestCase):
         self.assertEventEquals(self.event_map,
                                tx.logs[0], "OracleUpdated",
                                {"newOracle": new_oracle},
-                                self.havven_proxy.address)
+                               self.havven_proxy.address)
 
     def test_event_NominUpdated(self):
         new_nomin = fresh_account()
@@ -782,7 +780,7 @@ class TestHavven(HavvenTestCase):
         self.assertEventEquals(self.event_map,
                                tx.logs[0], "NominUpdated",
                                {"newNomin": new_nomin},
-                                self.havven_proxy.address)
+                               self.havven_proxy.address)
 
     def test_event_EscrowUpdated(self):
         new_escrow = fresh_account()
@@ -791,7 +789,7 @@ class TestHavven(HavvenTestCase):
         self.assertEventEquals(self.event_map,
                                tx.logs[0], "EscrowUpdated",
                                {"newEscrow": new_escrow},
-                                self.havven_proxy.address)
+                               self.havven_proxy.address)
 
     def test_event_IssuersUpdated(self):
         new_issuer = fresh_account()
@@ -801,11 +799,11 @@ class TestHavven(HavvenTestCase):
                                tx.logs[0], "IssuersUpdated",
                                {"account": new_issuer,
                                 "value": True},
-                                self.havven_proxy.address)
+                               self.havven_proxy.address)
         tx = self.havven.setIssuer(MASTER, new_issuer, False)
         self.assertEventEquals(self.event_map,
                                tx.logs[0], "IssuersUpdated",
                                {"account": new_issuer,
                                 "value": False},
-                                self.havven_proxy.address)
+                               self.havven_proxy.address)
 

--- a/tests/test_Havven.py
+++ b/tests/test_Havven.py
@@ -58,7 +58,7 @@ class TestHavven(HavvenTestCase):
         hvn_block = W3.eth.blockNumber
         nomin_contract, nom_txr = attempt_deploy(compiled, 'Nomin',
                                                  MASTER,
-                                                 [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, MASTER])
+                                                 [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, 0, MASTER])
         court_contract, court_txr = attempt_deploy(compiled, 'Court',
                                                    MASTER,
                                                    [havven_contract.address, nomin_contract.address,
@@ -171,6 +171,9 @@ class TestHavven(HavvenTestCase):
         self.assertEqual(self.havven.lastFeesCollected(), 0)
         self.assertEqual(self.havven.nomin(), self.nomin_contract.address)
         self.assertEqual(self.havven.decimals(), 18)
+
+        # Ensure issuers list updates issued balances properly
+        self.assertTrue(False)
 
     ###
     # Mappings

--- a/tests/test_Havven.py
+++ b/tests/test_Havven.py
@@ -44,6 +44,11 @@ class TestHavven(HavvenTestCase):
 
         compiled, cls.event_maps = cls.compileAndMapEvents(sources)
 
+        # Initial issued nomin balances
+        #issuer_addresses = [f"0x{'0'*39}{i+1}" for i in range(10)]
+        #issuer_balances = [77 * UNIT * i for i in range(10)]
+        #total_nomins = sum(issuer_balances)
+
         # Deploy contracts
         havven_proxy, _ = attempt_deploy(compiled, 'Proxy', MASTER, [MASTER])
         nomin_proxy, _ = attempt_deploy(compiled, 'Proxy', MASTER, [MASTER])
@@ -58,7 +63,7 @@ class TestHavven(HavvenTestCase):
         hvn_block = W3.eth.blockNumber
         nomin_contract, nom_txr = attempt_deploy(compiled, 'Nomin',
                                                  MASTER,
-                                                 [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, 0, MASTER])
+                                                 [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, total_nomins, MASTER])
         court_contract, court_txr = attempt_deploy(compiled, 'Court',
                                                    MASTER,
                                                    [havven_contract.address, nomin_contract.address,
@@ -172,7 +177,7 @@ class TestHavven(HavvenTestCase):
         self.assertEqual(self.havven.nomin(), self.nomin_contract.address)
         self.assertEqual(self.havven.decimals(), 18)
 
-        # Ensure issuers list updates issued balances properly
+        # Ensure issuers list updates issued balances properly... update deploycontracts above.
         self.assertTrue(False)
 
     ###

--- a/tests/test_Havven.py
+++ b/tests/test_Havven.py
@@ -52,7 +52,7 @@ class TestHavven(HavvenTestCase):
 
         tokenstate, _ = attempt_deploy(compiled, 'TokenState',
                                        MASTER, [MASTER, MASTER])
-        havven_contract, hvn_txr = attempt_deploy(compiled, 'PublicHavven', MASTER, [havven_proxy.address, tokenstate.address, MASTER, MASTER, UNIT//2])
+        havven_contract, hvn_txr = attempt_deploy(compiled, 'PublicHavven', MASTER, [havven_proxy.address, tokenstate.address, MASTER, MASTER, UNIT//2, [], []])
         hvn_block = W3.eth.blockNumber
         nomin_contract, nom_txr = attempt_deploy(compiled, 'Nomin',
                                                  MASTER,

--- a/tests/test_HavvenEscrow.py
+++ b/tests/test_HavvenEscrow.py
@@ -658,6 +658,7 @@ class TestHavvenEscrow(HavvenTestCase):
         self.assertEqual(self.havven.balanceOf(alice), 25 * UNIT)
         self.assertEqual(self.havven.balanceOf(self.escrow_contract.address), 175 * UNIT)
 
+        print()
         # Deploy the new havven contract, with proxy and all.
         havven_proxy, _ = attempt_deploy(self.compiled, 'Proxy', MASTER, [MASTER])
         havven_contract, _ = attempt_deploy(self.compiled, 'PublicHavven', MASTER, [havven_proxy.address, self.havven_token_state.address, MASTER, MASTER, UNIT//2, [], ZERO_ADDRESS])

--- a/tests/test_HavvenEscrow.py
+++ b/tests/test_HavvenEscrow.py
@@ -54,7 +54,7 @@ class TestHavvenEscrow(HavvenTestCase):
 
         tokenstate, _ = attempt_deploy(cls.compiled, 'TokenState',
                                        MASTER, [MASTER, MASTER])
-        havven_contract, hvn_txr = attempt_deploy(cls.compiled, 'PublicHavven', MASTER, [havven_proxy.address, tokenstate.address, MASTER, MASTER, UNIT//2])
+        havven_contract, hvn_txr = attempt_deploy(cls.compiled, 'PublicHavven', MASTER, [havven_proxy.address, tokenstate.address, MASTER, MASTER, UNIT//2, [], []])
         hvn_block = W3.eth.blockNumber
 
         nomin_contract, nom_txr = attempt_deploy(cls.compiled, 'PublicNomin',
@@ -657,7 +657,7 @@ class TestHavvenEscrow(HavvenTestCase):
 
         # Deploy the new havven contract, with proxy and all.
         havven_proxy, _ = attempt_deploy(self.compiled, 'Proxy', MASTER, [MASTER])
-        havven_contract, _ = attempt_deploy(self.compiled, 'PublicHavven', MASTER, [havven_proxy.address, self.havven_token_state.address, MASTER, MASTER, UNIT//2])
+        havven_contract, _ = attempt_deploy(self.compiled, 'PublicHavven', MASTER, [havven_proxy.address, self.havven_token_state.address, MASTER, MASTER, UNIT//2, [], []])
         proxied_havven = W3.eth.contract(address=havven_proxy.address, abi=self.compiled['PublicHavven']['abi'])
         new_havven = PublicHavvenInterface(proxied_havven, "Havven")
 

--- a/tests/test_HavvenEscrow.py
+++ b/tests/test_HavvenEscrow.py
@@ -56,7 +56,7 @@ class TestHavvenEscrow(HavvenTestCase):
                                               MASTER, [MASTER, MASTER])
         nomin_tokenstate, _ = attempt_deploy(cls.compiled, 'TokenState',
                                              MASTER, [MASTER, MASTER])
-        havven_contract, hvn_txr = attempt_deploy(cls.compiled, 'PublicHavven', MASTER, [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, UNIT//2, [], []])
+        havven_contract, hvn_txr = attempt_deploy(cls.compiled, 'PublicHavven', MASTER, [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, UNIT//2, [], ZERO_ADDRESS])
         hvn_block = W3.eth.blockNumber
 
         nomin_contract, nom_txr = attempt_deploy(cls.compiled, 'PublicNomin',
@@ -660,7 +660,7 @@ class TestHavvenEscrow(HavvenTestCase):
 
         # Deploy the new havven contract, with proxy and all.
         havven_proxy, _ = attempt_deploy(self.compiled, 'Proxy', MASTER, [MASTER])
-        havven_contract, _ = attempt_deploy(self.compiled, 'PublicHavven', MASTER, [havven_proxy.address, self.havven_token_state.address, MASTER, MASTER, UNIT//2, [], []])
+        havven_contract, _ = attempt_deploy(self.compiled, 'PublicHavven', MASTER, [havven_proxy.address, self.havven_token_state.address, MASTER, MASTER, UNIT//2, [], ZERO_ADDRESS])
         proxied_havven = W3.eth.contract(address=havven_proxy.address, abi=self.compiled['PublicHavven']['abi'])
         new_havven = PublicHavvenInterface(proxied_havven, "Havven")
 

--- a/tests/test_HavvenEscrow.py
+++ b/tests/test_HavvenEscrow.py
@@ -52,14 +52,16 @@ class TestHavvenEscrow(HavvenTestCase):
         proxied_havven = W3.eth.contract(address=havven_proxy.address, abi=cls.compiled['PublicHavven']['abi'])
         proxied_nomin = W3.eth.contract(address=nomin_proxy.address, abi=cls.compiled['PublicNomin']['abi'])
 
-        tokenstate, _ = attempt_deploy(cls.compiled, 'TokenState',
-                                       MASTER, [MASTER, MASTER])
-        havven_contract, hvn_txr = attempt_deploy(cls.compiled, 'PublicHavven', MASTER, [havven_proxy.address, tokenstate.address, MASTER, MASTER, UNIT//2, [], []])
+        havven_tokenstate, _ = attempt_deploy(cls.compiled, 'TokenState',
+                                              MASTER, [MASTER, MASTER])
+        nomin_tokenstate, _ = attempt_deploy(cls.compiled, 'TokenState',
+                                             MASTER, [MASTER, MASTER])
+        havven_contract, hvn_txr = attempt_deploy(cls.compiled, 'PublicHavven', MASTER, [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, UNIT//2, [], []])
         hvn_block = W3.eth.blockNumber
 
         nomin_contract, nom_txr = attempt_deploy(cls.compiled, 'PublicNomin',
                                                  MASTER,
-                                                 [nomin_proxy.address, havven_contract.address, MASTER])
+                                                 [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, MASTER])
         court_contract, court_txr = attempt_deploy(cls.compiled, 'Court',
                                                    MASTER,
                                                    [havven_contract.address, nomin_contract.address,
@@ -69,8 +71,9 @@ class TestHavvenEscrow(HavvenTestCase):
                                                      [MASTER, havven_contract.address])
 
         # Hook up each of those contracts to each other
-        mine_txs([tokenstate.functions.setBalanceOf(havven_contract.address, 100000000 * UNIT).transact({'from': MASTER}),
-                  tokenstate.functions.setAssociatedContract(havven_contract.address).transact({'from': MASTER}),
+        mine_txs([havven_tokenstate.functions.setBalanceOf(havven_contract.address, 100000000 * UNIT).transact({'from': MASTER}),
+                  havven_tokenstate.functions.setAssociatedContract(havven_contract.address).transact({'from': MASTER}),
+                  nomin_tokenstate.functions.setAssociatedContract(nomin_contract.address).transact({'from': MASTER}),
                   havven_proxy.functions.setTarget(havven_contract.address).transact({'from': MASTER}),
                   nomin_proxy.functions.setTarget(nomin_contract.address).transact({'from': MASTER}),
                   havven_contract.functions.setNomin(nomin_contract.address).transact({'from': MASTER}),
@@ -82,7 +85,7 @@ class TestHavvenEscrow(HavvenTestCase):
         havven_event_dict = generate_topic_event_map(cls.compiled['PublicHavven']['abi'])
 
         print("\nDeployment complete.\n")
-        return havven_proxy, proxied_havven, tokenstate, nomin_proxy, proxied_nomin, havven_contract, nomin_contract, court_contract, escrow_contract, hvn_block, escrow_event_dict, havven_event_dict
+        return havven_proxy, proxied_havven, havven_tokenstate, nomin_proxy, proxied_nomin, havven_contract, nomin_contract, court_contract, escrow_contract, hvn_block, escrow_event_dict, havven_event_dict
 
     @classmethod
     def setUpClass(cls):

--- a/tests/test_HavvenEscrow.py
+++ b/tests/test_HavvenEscrow.py
@@ -61,7 +61,7 @@ class TestHavvenEscrow(HavvenTestCase):
 
         nomin_contract, nom_txr = attempt_deploy(cls.compiled, 'PublicNomin',
                                                  MASTER,
-                                                 [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, MASTER])
+                                                 [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, 0, MASTER])
         court_contract, court_txr = attempt_deploy(cls.compiled, 'Court',
                                                    MASTER,
                                                    [havven_contract.address, nomin_contract.address,

--- a/tests/test_Issuance.py
+++ b/tests/test_Issuance.py
@@ -93,9 +93,6 @@ class TestIssuance(HavvenTestCase):
         cls.fake_court = FakeCourtInterface(cls.fake_court_contract, "FakeCourt")
         cls.fake_court.setNomin(MASTER, cls.nomin_contract.address)
     
-    def test_constructor_issuers(self):
-        self.assertTrue(False)
-
     def havven_updatePrice(self, sender, price, time):
         mine_tx(self.havven_contract.functions.updatePrice(price, time).transact({'from': sender}), 'updatePrice', 'Havven')
 

--- a/tests/test_Issuance.py
+++ b/tests/test_Issuance.py
@@ -113,7 +113,7 @@ class TestIssuance(HavvenTestCase):
 
         self.assertEqual(self.havven.balanceOf(alice), 0)
         self.assertEqual(self.nomin.balanceOf(alice), 100 * UNIT)
-        self.assertClose(self.havven.availableHavvens(alice) + 100 * UNIT / (self.havven.issuanceRatio() / UNIT), self.havven.totalSupply() // 2)
+        self.assertClose(self.havven.availableCollateral(alice) + 100 * UNIT / (self.havven.issuanceRatio() / UNIT), self.havven.totalSupply() // 2)
 
     def test_issuance_price_shift(self):
         alice = fresh_account()
@@ -122,13 +122,13 @@ class TestIssuance(HavvenTestCase):
         self.havven.setIssuer(MASTER, alice, True)
         self.havven_updatePrice(self.havven.oracle(), UNIT, self.havven.currentTime() + 1)
         self.havven.issueNomins(alice, 10 * UNIT)
-        self.assertEqual(self.havven.availableHavvens(alice), 800 * UNIT)
+        self.assertEqual(self.havven.availableCollateral(alice), 800 * UNIT)
         fast_forward(2)
         self.havven_updatePrice(self.havven.oracle(), 100 * UNIT, self.havven.currentTime() + 1)
-        self.assertEqual(self.havven.availableHavvens(alice), 998 * UNIT)
+        self.assertEqual(self.havven.availableCollateral(alice), 998 * UNIT)
         fast_forward(2)
         self.havven_updatePrice(self.havven.oracle(), int(0.01 * UNIT), self.havven.currentTime() + 1)
-        self.assertEqual(self.havven.availableHavvens(alice), 0)
+        self.assertEqual(self.havven.availableCollateral(alice), 0)
 
         self.assertReverts(self.havven.transfer, alice, MASTER, 1)
 

--- a/tests/test_Issuance.py
+++ b/tests/test_Issuance.py
@@ -55,7 +55,7 @@ class TestIssuance(HavvenTestCase):
                                                   [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, UNIT//2, [], []])
         nomin_contract, nom_txr = attempt_deploy(compiled, 'PublicNomin',
                                                  MASTER,
-                                                 [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, MASTER])
+                                                 [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, 0, MASTER])
         court_contract, court_txr = attempt_deploy(compiled, 'FakeCourt',
                                                    MASTER,
                                                    [havven_contract.address, nomin_contract.address,

--- a/tests/test_Issuance.py
+++ b/tests/test_Issuance.py
@@ -49,7 +49,7 @@ class TestIssuance(HavvenTestCase):
         tokenstate, _ = attempt_deploy(compiled, 'TokenState',
                                        MASTER, [MASTER, MASTER])
         havven_contract, hvn_txr = attempt_deploy(compiled, 'PublicHavven', MASTER,
-                                                  [havven_proxy.address, tokenstate.address, MASTER, MASTER, UNIT//2])
+                                                  [havven_proxy.address, tokenstate.address, MASTER, MASTER, UNIT//2, [], []])
 
         nomin_contract, nom_txr = attempt_deploy(compiled, 'PublicNomin',
                                                  MASTER,

--- a/tests/test_Issuance.py
+++ b/tests/test_Issuance.py
@@ -87,6 +87,9 @@ class TestIssuance(HavvenTestCase):
 
         cls.fake_court = FakeCourtInterface(cls.fake_court_contract, "FakeCourt")
         cls.fake_court.setNomin(MASTER, cls.nomin_contract.address)
+    
+    def test_constructor_issuers(self):
+        self.assertTrue(False)
 
     def havven_updatePrice(self, sender, price, time):
         mine_tx(self.havven_contract.functions.updatePrice(price, time).transact({'from': sender}), 'updatePrice', 'Havven')
@@ -173,5 +176,26 @@ class TestIssuance(HavvenTestCase):
             self.havven.burnNomins(alice, 1 * UNIT)
         self.assertEqual(self.havven.nominsIssued(alice), 0)
         self.assertEqual(self.nomin.balanceOf(alice), 0)
+
+    def test_transfer_locked_havvens(self):
+        self.assertTrue(False)
+
+    def test_transferFrom_locked_havvens(self):
+        self.assertTrue(False)
+
+    def test_collateral(self):
+        self.assertTrue(False)
+
+    def test_issuanceDraft(self):
+        self.assertTrue(False)
+
+    def test_unavailableCollateral(self):
+        self.assertTrue(False)
+
+    def test_availableCollateral(self):
+        self.assertTrue(False)
+
+    def test_transferableHavvens(self):
+        self.assertTrue(False)
 
 

--- a/tests/test_Issuance.py
+++ b/tests/test_Issuance.py
@@ -119,7 +119,7 @@ class TestIssuance(HavvenTestCase):
 
         self.assertEqual(self.havven.balanceOf(alice), 0)
         self.assertEqual(self.nomin.balanceOf(alice), 100 * UNIT)
-        self.assertClose(self.havven.availableCollateral(alice) + 100 * UNIT / (self.havven.issuanceRatio() / UNIT), self.havven.totalSupply() // 2)
+        self.assertClose(self.havven.unlockedCollateral(alice) + 100 * UNIT / (self.havven.issuanceRatio() / UNIT), self.havven.totalSupply() // 2)
 
     def test_issuance_price_shift(self):
         alice = fresh_account()
@@ -128,13 +128,13 @@ class TestIssuance(HavvenTestCase):
         self.havven.setIssuer(MASTER, alice, True)
         self.havven_updatePrice(self.havven.oracle(), UNIT, self.havven.currentTime() + 1)
         self.havven.issueNomins(alice, 10 * UNIT)
-        self.assertEqual(self.havven.availableCollateral(alice), 800 * UNIT)
+        self.assertEqual(self.havven.unlockedCollateral(alice), 800 * UNIT)
         fast_forward(2)
         self.havven_updatePrice(self.havven.oracle(), 100 * UNIT, self.havven.currentTime() + 1)
-        self.assertEqual(self.havven.availableCollateral(alice), 998 * UNIT)
+        self.assertEqual(self.havven.unlockedCollateral(alice), 998 * UNIT)
         fast_forward(2)
         self.havven_updatePrice(self.havven.oracle(), int(0.01 * UNIT), self.havven.currentTime() + 1)
-        self.assertEqual(self.havven.availableCollateral(alice), 0)
+        self.assertEqual(self.havven.unlockedCollateral(alice), 0)
 
         self.assertReverts(self.havven.transfer, alice, MASTER, 1)
 
@@ -203,10 +203,10 @@ class TestIssuance(HavvenTestCase):
     def test_issuanceDraft(self):
         self.assertTrue(False)
 
-    def test_unavailableCollateral(self):
+    def test_lockedCollateral(self):
         self.assertTrue(False)
 
-    def test_availableCollateral(self):
+    def test_unlockedCollateral(self):
         self.assertTrue(False)
 
     def test_transferableHavvens(self):

--- a/tests/test_Issuance.py
+++ b/tests/test_Issuance.py
@@ -52,7 +52,7 @@ class TestIssuance(HavvenTestCase):
                                              MASTER, [MASTER, MASTER])
 
         havven_contract, hvn_txr = attempt_deploy(compiled, 'PublicHavven', MASTER,
-                                                  [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, UNIT//2, [], []])
+                                                  [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, cls.initial_price, [], ZERO_ADDRESS])
         nomin_contract, nom_txr = attempt_deploy(compiled, 'PublicNomin',
                                                  MASTER,
                                                  [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, 0, MASTER])
@@ -80,11 +80,13 @@ class TestIssuance(HavvenTestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.initial_price = UNIT // 2
         cls.havven_proxy, cls.proxied_havven, cls.nomin_proxy, cls.proxied_nomin, cls.havven_contract, cls.nomin_contract, cls.fake_court_contract, cls.escrow_contract = cls.deployContracts()
 
         cls.havven = PublicHavvenInterface(cls.proxied_havven, "Havven")
         cls.nomin = PublicNominInterface(cls.proxied_nomin, "Nomin")
         cls.escrow = PublicHavvenEscrowInterface(cls.escrow_contract, "HavvenEscrow")
+        cls.havven.setIssuanceRatio(MASTER, UNIT // 20)
 
         fast_forward(weeks=102)
 

--- a/tests/test_IssuanceController.py
+++ b/tests/test_IssuanceController.py
@@ -52,7 +52,7 @@ class TestIssuanceController(HavvenTestCase):
         nomin_tokenstate, _ = attempt_deploy(compiled, 'TokenState',
                                              MASTER, [MASTER, MASTER])
         havven_contract, hvn_txr = attempt_deploy(
-            compiled, 'PublicHavven', MASTER, [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, UNIT//2, [], []]
+            compiled, 'PublicHavven', MASTER, [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, UNIT//2, [], ZERO_ADDRESS]
         )
         nomin_contract, nom_txr = attempt_deploy(
             compiled, 'PublicNomin', MASTER, [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, 0, MASTER]

--- a/tests/test_IssuanceController.py
+++ b/tests/test_IssuanceController.py
@@ -50,7 +50,7 @@ class TestIssuanceController(HavvenTestCase):
         tokenstate, _ = attempt_deploy(compiled, 'TokenState',
                                        MASTER, [MASTER, MASTER])
         havven_contract, hvn_txr = attempt_deploy(
-            compiled, 'PublicHavven', MASTER, [havven_proxy.address, tokenstate.address, MASTER, MASTER, UNIT//2]
+            compiled, 'PublicHavven', MASTER, [havven_proxy.address, tokenstate.address, MASTER, MASTER, UNIT//2, [], []]
         )
         nomin_contract, nom_txr = attempt_deploy(
             compiled, 'PublicNomin', MASTER, [nomin_proxy.address, havven_contract.address, MASTER]

--- a/tests/test_IssuanceController.py
+++ b/tests/test_IssuanceController.py
@@ -55,7 +55,7 @@ class TestIssuanceController(HavvenTestCase):
             compiled, 'PublicHavven', MASTER, [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, UNIT//2, [], []]
         )
         nomin_contract, nom_txr = attempt_deploy(
-            compiled, 'PublicNomin', MASTER, [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, MASTER]
+            compiled, 'PublicNomin', MASTER, [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, 0, MASTER]
         )
 
         mine_txs([

--- a/tests/test_IssuanceController.py
+++ b/tests/test_IssuanceController.py
@@ -47,18 +47,21 @@ class TestIssuanceController(HavvenTestCase):
         proxied_havven = W3.eth.contract(address=havven_proxy.address, abi=havven_abi)
         proxied_nomin = W3.eth.contract(address=nomin_proxy.address, abi=nomin_abi)
 
-        tokenstate, _ = attempt_deploy(compiled, 'TokenState',
-                                       MASTER, [MASTER, MASTER])
+        havven_tokenstate, _ = attempt_deploy(compiled, 'TokenState',
+                                              MASTER, [MASTER, MASTER])
+        nomin_tokenstate, _ = attempt_deploy(compiled, 'TokenState',
+                                             MASTER, [MASTER, MASTER])
         havven_contract, hvn_txr = attempt_deploy(
-            compiled, 'PublicHavven', MASTER, [havven_proxy.address, tokenstate.address, MASTER, MASTER, UNIT//2, [], []]
+            compiled, 'PublicHavven', MASTER, [havven_proxy.address, havven_tokenstate.address, MASTER, MASTER, UNIT//2, [], []]
         )
         nomin_contract, nom_txr = attempt_deploy(
-            compiled, 'PublicNomin', MASTER, [nomin_proxy.address, havven_contract.address, MASTER]
+            compiled, 'PublicNomin', MASTER, [nomin_proxy.address, nomin_tokenstate.address, havven_contract.address, MASTER]
         )
 
         mine_txs([
-            tokenstate.functions.setBalanceOf(havven_contract.address, 100000000 * UNIT).transact({'from': MASTER}),
-            tokenstate.functions.setAssociatedContract(havven_contract.address).transact({'from': MASTER}),
+            havven_tokenstate.functions.setBalanceOf(havven_contract.address, 100000000 * UNIT).transact({'from': MASTER}),
+            havven_tokenstate.functions.setAssociatedContract(havven_contract.address).transact({'from': MASTER}),
+            nomin_tokenstate.functions.setAssociatedContract(nomin_contract.address).transact({'from': MASTER}),
             havven_proxy.functions.setTarget(havven_contract.address).transact({'from': MASTER}),
             nomin_proxy.functions.setTarget(nomin_contract.address).transact({'from': MASTER}),
             havven_contract.functions.setNomin(nomin_contract.address).transact({'from': MASTER}),

--- a/tests/test_Nomin.py
+++ b/tests/test_Nomin.py
@@ -46,7 +46,7 @@ class TestNomin(HavvenTestCase):
         )
 
         havven_contract, _ = attempt_deploy(
-            compiled, "Havven", MASTER, [havven_proxy.address, ZERO_ADDRESS, MASTER, MASTER, UNIT//2]
+            compiled, "Havven", MASTER, [havven_proxy.address, ZERO_ADDRESS, MASTER, MASTER, UNIT//2, [], []]
         )
 
         fake_court, _ = attempt_deploy(compiled, 'FakeCourt', MASTER, [])

--- a/tests/test_Nomin.py
+++ b/tests/test_Nomin.py
@@ -46,7 +46,7 @@ class TestNomin(HavvenTestCase):
             [MASTER, MASTER]
         )
         nomin_contract, _ = attempt_deploy(
-            compiled, 'PublicNomin', MASTER, [nomin_proxy.address, nomin_state.address, MASTER, MASTER]
+            compiled, 'PublicNomin', MASTER, [nomin_proxy.address, nomin_state.address, MASTER, 0, MASTER]
         )
 
         havven_contract, _ = attempt_deploy(
@@ -198,7 +198,7 @@ class TestNomin(HavvenTestCase):
             self.nomin_event_dict, txr.logs[1], 'Transfer',
             fields={
                 'from': sender,
-                'to': self.nomin_contract.address,
+                'to': self.nomin_contract.functions.FEE_ADDRESS().call(),
                 'value': fee
             },
             location=self.nomin_proxy.address
@@ -228,7 +228,7 @@ class TestNomin(HavvenTestCase):
             self.nomin_event_dict, txr.logs[1], 'Transfer',
             fields={
                 'from': MASTER,
-                'to': self.nomin_contract.address,
+                'to': self.nomin_contract.functions.FEE_ADDRESS().call(),
                 'value': fee
             },
             location=self.nomin_proxy.address
@@ -250,7 +250,7 @@ class TestNomin(HavvenTestCase):
             self.nomin_event_dict, txr.logs[1], 'Transfer',
             fields={
                 'from': target,
-                'to': self.nomin_contract.address,
+                'to': self.nomin_contract.functions.FEE_ADDRESS().call(),
                 'value': amountReceived
             },
             location=self.nomin_proxy.address
@@ -284,7 +284,7 @@ class TestNomin(HavvenTestCase):
             self.nomin_event_dict, txr.logs[1], 'Transfer',
             fields={
                 'from': MASTER,
-                'to': self.nomin_contract.address,
+                'to': self.nomin_contract.functions.FEE_ADDRESS().call(),
                 'value': fee
             },
             location=self.nomin_proxy.address
@@ -339,7 +339,7 @@ class TestNomin(HavvenTestCase):
             self.nomin_event_dict, txr.logs[1], 'Transfer',
             fields={
                 'from': MASTER,
-                'to': self.nomin_contract.address,
+                'to': self.nomin_contract.functions.FEE_ADDRESS().call(),
                 'value': fee
             },
             location=self.nomin_proxy.address
@@ -360,7 +360,7 @@ class TestNomin(HavvenTestCase):
             self.nomin_event_dict, txr.logs[1], 'Transfer',
             fields={
                 'from': target,
-                'to': self.nomin_contract.address,
+                'to': self.nomin_contract.functions.FEE_ADDRESS().call(),
                 'value': self.nomin.amountReceived(5 * UNIT)
             },
             location=self.nomin_proxy.address
@@ -391,7 +391,7 @@ class TestNomin(HavvenTestCase):
             self.nomin_event_dict, txr.logs[1], 'Transfer',
             fields={
                 'from': MASTER,
-                'to': self.nomin_contract.address,
+                'to': self.nomin_contract.functions.FEE_ADDRESS().call(),
                 'value': fee
             },
             location=self.nomin_proxy.address
@@ -421,7 +421,7 @@ class TestNomin(HavvenTestCase):
             self.nomin_event_dict, txr.logs[1], 'Transfer',
             fields={
                 'from': MASTER,
-                'to': self.nomin_contract.address,
+                'to': self.nomin_contract.functions.FEE_ADDRESS().call(),
                 'value': self.nomin.transferFeeIncurred(5 * UNIT)
             },
             location=self.nomin_proxy.address
@@ -442,7 +442,7 @@ class TestNomin(HavvenTestCase):
             self.nomin_event_dict, txr.logs[1], 'Transfer',
             fields={
                 'from': target,
-                'to': self.nomin_contract.address,
+                'to': self.nomin_contract.functions.FEE_ADDRESS().call(),
                 'value': 5 * UNIT
             },
             location=self.nomin_proxy.address
@@ -475,7 +475,7 @@ class TestNomin(HavvenTestCase):
             self.nomin_event_dict, txr.logs[1], 'Transfer',
             fields={
                 'from': MASTER,
-                'to': self.nomin_contract.address,
+                'to': self.nomin_contract.functions.FEE_ADDRESS().call(),
                 'value': self.nomin.transferFeeIncurred(self.nomin.amountReceived(old_bal))
             },
             location=self.nomin_proxy.address

--- a/tests/test_Nomin.py
+++ b/tests/test_Nomin.py
@@ -571,8 +571,9 @@ class TestNomin(HavvenTestCase):
     def test_unfreezeAccount(self):
         target = fresh_account()
 
-        # The nomin contract itself should not be unfreezable.
-        self.assertReverts(self.nomin.unfreezeAccount, MASTER, self.nomin_contract.address)
+        # The fee address should not be unfreezable.
+        self.assertTrue(self.nomin.frozen(self.nomin.FEE_ADDRESS()))
+        self.assertReverts(self.nomin.unfreezeAccount, MASTER, self.nomin.FEE_ADDRESS())
         self.assertTrue(self.nomin.frozen(self.nomin.FEE_ADDRESS()))
 
         # Unfreezing non-frozen accounts should not do anything.

--- a/tests/test_Nomin.py
+++ b/tests/test_Nomin.py
@@ -78,17 +78,14 @@ class TestNomin(HavvenTestCase):
         cls.unproxied_nomin = PublicNominInterface(cls.nomin_contract, "UnproxiedNomin")
 
         cls.fake_court = FakeCourtInterface(cls.fake_court_contract, "FakeCourt")
-
         cls.fake_court.setNomin(MASTER, cls.nomin_contract.address)
-
         cls.nomin.setFeeAuthority(MASTER, cls.havven_contract.address)
-
         cls.sd_duration = 4 * 7 * 24 * 60 * 60
 
     def test_constructor(self):
         # Nomin-specific members
         self.assertEqual(self.nomin.owner(), MASTER)
-        self.assertTrue(self.nomin.frozen(self.nomin_contract.address))
+        self.assertTrue(self.nomin.frozen(self.nomin.FEE_ADDRESS()))
 
         # FeeToken members
         self.assertEqual(self.nomin.name(), "Nomin USD")
@@ -576,7 +573,7 @@ class TestNomin(HavvenTestCase):
 
         # The nomin contract itself should not be unfreezable.
         self.assertReverts(self.nomin.unfreezeAccount, MASTER, self.nomin_contract.address)
-        self.assertTrue(self.nomin.frozen(self.nomin_contract.address))
+        self.assertTrue(self.nomin.frozen(self.nomin.FEE_ADDRESS()))
 
         # Unfreezing non-frozen accounts should not do anything.
         self.assertFalse(self.nomin.frozen(target))

--- a/tests/test_Nomin.py
+++ b/tests/test_Nomin.py
@@ -50,7 +50,7 @@ class TestNomin(HavvenTestCase):
         )
 
         havven_contract, _ = attempt_deploy(
-            compiled, "Havven", MASTER, [havven_proxy.address, ZERO_ADDRESS, MASTER, MASTER, UNIT//2, [], []]
+            compiled, "Havven", MASTER, [havven_proxy.address, ZERO_ADDRESS, MASTER, MASTER, UNIT//2, [], ZERO_ADDRESS]
         )
 
         fake_court, _ = attempt_deploy(compiled, 'FakeCourt', MASTER, [])

--- a/tests/test_Proxy.py
+++ b/tests/test_Proxy.py
@@ -44,19 +44,20 @@ class TestFeeToken(HavvenTestCase):
         proxied_feetoken = W3.eth.contract(address=proxy.address, abi=feetoken_abi)
 
         feetoken_event_dict = generate_topic_event_map(feetoken_abi)
-        feetoken_contract_1, construction_txr_1 = attempt_deploy(
-            compiled, "PublicFeeToken", MASTER,
-            [proxy.address, "Test Fee Token", "FEE", UNIT // 20, MASTER, MASTER]
-        )
-
-        feetoken_contract_2, construction_txr_2 = attempt_deploy(
-            compiled, "PublicFeeToken", MASTER,
-            [proxy.address, "Test Fee Token 2", "FEE", UNIT // 20, MASTER, MASTER]
-        )
 
         feestate, txr = attempt_deploy(
             compiled, "TokenState", MASTER,
             [MASTER, MASTER]
+        )
+
+        feetoken_contract_1, construction_txr_1 = attempt_deploy(
+            compiled, "PublicFeeToken", MASTER,
+            [proxy.address, feestate.address, "Test Fee Token", "FEE", UNIT // 20, MASTER, MASTER]
+        )
+
+        feetoken_contract_2, construction_txr_2 = attempt_deploy(
+            compiled, "PublicFeeToken", MASTER,
+            [proxy.address, feestate.address, "Test Fee Token 2", "FEE", UNIT // 20, MASTER, MASTER]
         )
 
         mine_txs([

--- a/tests/test_Proxy.py
+++ b/tests/test_Proxy.py
@@ -52,12 +52,12 @@ class TestFeeToken(HavvenTestCase):
 
         feetoken_contract_1, construction_txr_1 = attempt_deploy(
             compiled, "PublicFeeToken", MASTER,
-            [proxy.address, feestate.address, "Test Fee Token", "FEE", UNIT // 20, MASTER, MASTER]
+            [proxy.address, feestate.address, "Test Fee Token", "FEE", 1000 * UNIT, UNIT // 20, MASTER, MASTER]
         )
 
         feetoken_contract_2, construction_txr_2 = attempt_deploy(
             compiled, "PublicFeeToken", MASTER,
-            [proxy.address, feestate.address, "Test Fee Token 2", "FEE", UNIT // 20, MASTER, MASTER]
+            [proxy.address, feestate.address, "Test Fee Token 2", "FEE", 1000 * UNIT, UNIT // 20, MASTER, MASTER]
         )
 
         mine_txs([
@@ -90,7 +90,7 @@ class TestFeeToken(HavvenTestCase):
     def test_swap(self):
         self.assertEqual(self.feetoken.name(), "Test Fee Token")
         self.assertEqual(self.feetoken.symbol(), "FEE")
-        self.assertEqual(self.feetoken.totalSupply(), 0)
+        self.assertEqual(self.feetoken.totalSupply(), 1000 * UNIT)
         self.assertEqual(self.feetoken.transferFeeRate(), UNIT // 20)
         self.assertEqual(self.feetoken.feeAuthority(), self.fee_authority)
         self.assertEqual(self.feetoken.tokenState(), self.feestate.contract.address)


### PR DESCRIPTION
- added two arrays to constructor, to set issuers/nominsIssued for current issuers
- within transfers changed checking availableHavvens(sender) to new function transferableHavvens(sender)
- changed withdrawFee() to be external, from public
- changed name updateIssuanceData to computeIssuanceData
- changed remainingIssuableNomins to use safeSub
- added collateral function: havven.balanceOf(addr) + escrow.balanceOf(addr)
- renamed lockedHavvens to issuanceDraft, as it can go over the collateral of an address
- added lockedHavvens function, which caps the issuanceDraft up to the collateral of an address
- added transferableHavvens function which returns the number of havvens a user can transfer, considering the amount they have locked
- changed availableHavvens to use the collateral function rather than computing it
- fees now stored in a static address rather than in the underlying contract itself.
- constructor of Nomin now takes a total supply and a TokenState contract.

TODO: add a test for the constructor adding issuers